### PR TITLE
Sends more useful errors when creating a mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,32 @@ Requires WordPress 4.5+ or the [WP REST API plugin](https://github.com/WP-API/WP
 
 ## Usage
 
-You need to include and instantiate the controller:
+You need to include and instantiate the controllers:
 
 ```php
-add_action( 'rest_api_init', function() {
-    include 'class-rest-api.php';
-    $api = new Mercator\REST_API;
-    $api->register_routes();
-} );
+require_once 'api.php';
 ```
 
-The controller adds two API routes:
+### Mappings
+
+The mappings controller adds two API routes:
 
 ```
 /wp-json/mercator/v1/mappings       // accepts GET, POST
 /wp-json/mercator/v1/mappings/:id   // accepts PUT, PATCH, DELETE
 ```
 
-You can additionally specify a blog ID by passing in a `GET` parameter:
+You can additionally specify a blog ID by sending in a parameter:
 
 ```
-/wp-json/mercator/v1/mappings?blog=1
+GET
+curl http://wordpress.dev/wp-json/mercator/v1/mappings?blog=1
+
+POST, PUT, PATCH, DELETE
+curl --data "blog=1" http://wordpress.dev/wp-json/mercator/v1/mappings
 ```
 
-### Data structure
+#### Data structure
 
 Mappings are very simple. The example JSON object for a mapping is as follows:
 
@@ -41,4 +43,21 @@ Mappings are very simple. The example JSON object for a mapping is as follows:
 }
 ```
 
-When creating a mapping using `POST` you only need to send the `domain` and `active` values.
+When creating a mapping using `POST` you should only send the `domain` and `active` values.
+
+### Primary domain
+
+The primary domain controller adds a single route for getting and setting the primary domain.
+
+```
+/wp-json/mercator/v1/primary     // accepts GET, POST
+```
+
+When `POST`ing to this route you must send a mapping ID:
+
+```
+curl --data "mapping=123" http://wordpress.dev/wp-json/mercator/v1/primary
+```
+
+The mapping for that ID will made into the site's primary domain provided the user has 
+permission and the old primary domain will be converted into a new mapping.

--- a/api.php
+++ b/api.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Mercator REST API
+ *
+ * WordPress multisite domain mapping API.
+ *
+ * @package Mercator
+ */
+
+namespace Mercator\REST;
+
+add_action( 'rest_api_init', __NAMESPACE__ . '\\rest_api_init' );
+
+/**
+ * Load REST Controller
+ */
+function rest_api_init() {
+	if ( class_exists( 'Mercator\REST\Mappings_Controller' ) ) {
+		return;
+	}
+	require_once __DIR__ . '/classes/class-rest-mappings-controller.php';
+	require_once __DIR__ . '/classes/class-rest-primary-domain-controller.php';
+
+	// Mappings.
+	$mappings = new Mappings_Controller;
+	$mappings->register_routes();
+
+	// Primary domains.
+	$primary = new Primary_Domain_Controller();
+	$primary->register_routes();
+}

--- a/classes/class-rest-mappings-controller.php
+++ b/classes/class-rest-mappings-controller.php
@@ -85,7 +85,7 @@ class Mappings_Controller extends WP_REST_Controller {
 	public function get_items( $request ) {
 		$site  = $this->get_blog_id( $request );
 		$items = array_map( function ( $mapping ) use ( $request ) {
-			return $this->prepare_item_for_response( $mapping, $request );
+			return $this->mapping_to_array( $mapping, $request );
 		}, Mapping::get_by_site( $site ) );
 		return new WP_REST_Response( $items );
 	}
@@ -235,16 +235,7 @@ class Mappings_Controller extends WP_REST_Controller {
 			return new WP_REST_Response( $item );
 		}
 
-		$data = array(
-			'id'     => absint( $item->get_id() ),
-			'domain' => $item->get_domain(),
-			'active' => $item->is_active(),
-		);
-
-		// Return blog ID if sent
-		if ( null !== $request->get_param( 'blog' ) ) {
-			$data['blog'] = $request->get_param( 'blog' );
-		}
+		$data = $this->mapping_to_array( $item, $request );
 
 		return new WP_REST_Response( $data );
 	}
@@ -304,8 +295,30 @@ class Mappings_Controller extends WP_REST_Controller {
 	 * @param WP_REST_Request $request
 	 * @return int
 	 */
-	protected function get_blog_id( $request ) {
+	public function get_blog_id( $request ) {
 		return $request->get_param( 'blog' ) ?: get_current_blog_id();
+	}
+
+	/**
+	 * Converts a mapping to an array of data
+	 *
+	 * @param Mapping $mapping
+	 * @param WP_REST_Request|null $request
+	 * @return array
+	 */
+	protected function mapping_to_array( $mapping, $request = null ) {
+		$data = array(
+			'id'     => absint( $mapping->get_id() ),
+			'domain' => $mapping->get_domain(),
+			'active' => $mapping->is_active(),
+		);
+
+		// Return blog ID if sent
+		if ( null !== $request->get_param( 'blog' ) ) {
+			$data['blog'] = $request->get_param( 'blog' );
+		}
+
+		return $data;
 	}
 
 }

--- a/classes/class-rest-mappings-controller.php
+++ b/classes/class-rest-mappings-controller.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Mercator;
+namespace Mercator\REST;
 
+use Mercator\Mapping;
 use WP_REST_Controller;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -9,13 +10,22 @@ use WP_REST_Server;
 use WP_Error;
 use stdClass;
 
-class REST_API extends WP_REST_Controller {
+class Mappings_Controller extends WP_REST_Controller {
+
+	public $version = 'v1';
+	public $namespace;
+	public $rest_base;
+
+	public function __construct() {
+		$this->namespace = "mercator/{$this->version}";
+		$this->rest_base = 'mappings';
+	}
 
 	/**
 	 * Register the routes for the objects of the controller.
 	 */
 	public function register_routes() {
-		register_rest_route( 'mercator/v1', 'mappings', array(
+		register_rest_route( $this->namespace, $this->rest_base, array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
@@ -30,7 +40,7 @@ class REST_API extends WP_REST_Controller {
 
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
-		register_rest_route( 'mercator/v1', 'mappings/(?P<id>[\\d]+)', array(
+		register_rest_route( $this->namespace, "{$this->rest_base}/(?P<id>[\\d]+)", array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),

--- a/classes/class-rest-primary-domain-controller.php
+++ b/classes/class-rest-primary-domain-controller.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Mercator\REST;
+
+use Mercator\Mapping;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use WP_Error;
+
+class Primary_Domain_Controller extends WP_REST_Controller {
+
+	private $parent_controller;
+	private $parent_namespace;
+	private $rest_base;
+
+	/**
+	 * Primary_Domain_Controller constructor.
+	 */
+	public function __construct() {
+		$this->parent_controller = new Mappings_Controller();
+		$this->parent_namespace  = $this->parent_controller->namespace;
+		$this->rest_base         = 'primary';
+	}
+
+	/**
+	 * Register the routes for the objects of the controller.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->parent_namespace, $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_item' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				'args'                => array(
+					'mapping' => array(
+						'sanitize_callback' => 'absint',
+						'required'          => true,
+					),
+				),
+			),
+
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Check if a given request has access to get a specific item.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		return $this->parent_controller->get_item_permissions_check( $request );
+	}
+
+	/**
+	 * Get one item from the collection.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		return $this->prepare_item_for_response( null, $request );
+	}
+
+	/**
+	 * Check if a given request has access to create items.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function create_item_permissions_check( $request ) {
+		return $this->get_item_permissions_check( $request );
+	}
+
+	/**
+	 * Create one item from the collection.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		$mapping_id = $request->get_param( 'mapping' );
+		$mapping    = Mapping::get( $mapping_id );
+
+		if ( is_wp_error( $mapping ) ) {
+			return $mapping;
+		}
+
+		if ( null === $mapping ) {
+			return new WP_Error( __( 'You must supply a valid mapping ID to set as the primary domain via the `mapping` parameter.', 'mercator' ) );
+		}
+
+		$result = $mapping->make_primary();
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return $this->prepare_item_for_response( null, $request );
+	}
+
+
+	/**
+	 * Prepare the item for the REST response.
+	 *
+	 * @param mixed           $item    WordPress representation of the item.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+
+		$blog = $this->get_blog_id( $request );
+		$item = get_site( $blog );
+
+		if ( is_wp_error( $item ) || is_null( $item ) ) {
+			return new WP_REST_Response( $item );
+		}
+
+		// Get object vars
+		$data = $item->to_array();
+
+		return new WP_REST_Response( $data );
+	}
+
+	/**
+	 * JSON Schema for mappings
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'site',
+			'type'       => 'object',
+			'required'   => array(
+				'blog_id',
+				'domain',
+			),
+			/*
+			 * Base properties for every Alias.
+			 */
+			'properties' => array(
+				'blog_id'      => array(
+					'description' => __( 'Unique identifier for the object.' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'domain'       => array(
+					'description' => __( 'The domain name of the site' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'path'         => array(
+					'description' => __( 'The path name of the blog on a subfolder install' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'site_id'      => array(
+					'description' => __( 'The network ID this blog belongs to.' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'registered'   => array(
+					'description' => __( 'The date the blog was registered' ),
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'last_updated' => array(
+					'description' => __( 'The date the blog was last updated' ),
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'public'       => array(
+					'description' => __( 'Whether the blog is public or not' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'archived'     => array(
+					'description' => __( 'Whether the blog is archived or not' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'mature'       => array(
+					'description' => __( 'Whether the blog is for mature audiences or not' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'spam'         => array(
+					'description' => __( 'Whether the blog is marked as spam or not' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'deleted'      => array(
+					'description' => __( 'Whether the blog has been deleted or not' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'lang_id'      => array(
+					'description' => __( 'The language code for the blog' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $schema;
+	}
+
+}

--- a/classes/class-rest-primary-domain-controller.php
+++ b/classes/class-rest-primary-domain-controller.php
@@ -117,7 +117,7 @@ class Primary_Domain_Controller extends WP_REST_Controller {
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 
-		$blog = $this->get_blog_id( $request );
+		$blog = $this->parent_controller->get_blog_id( $request );
 		$item = get_site( $blog );
 
 		if ( is_wp_error( $item ) || is_null( $item ) ) {


### PR DESCRIPTION
This one is important for making a good UI but I'm not totes sure whether some of this should be done at the core Mercator level or not. The create method currently returns the mapping if it existed already so you can't tell what happened.

Should all WP_Errors thrown provide a message and HTTP code statuses in the core plugin?

cc @rmccue - would appreciate your thoughts on this, thinking it's ok to handle custom errors or extra data on errors in the API controller?